### PR TITLE
Remove special case for lists

### DIFF
--- a/punq/__init__.py
+++ b/punq/__init__.py
@@ -510,9 +510,6 @@ class Container:
 
         target = context.target(service_key)
 
-        if target.is_generic_list():
-            return self.resolve_all(target.generic_parameter)
-
         registration = target.next_impl()
 
         if registration is None and default is not None:


### PR DESCRIPTION
Before this PR the following code 
```
from typing import List

import punq

container = punq.Container()

container.register(List[str], instance=['hi'])
print(container.resolve(List[str]))
print(container.resolve(List[str]))
print(container.resolve_all(List[str]))
print(container.resolve(List[str]))
```
would result in 
```
[]
[]
[['hi']]
['hi']
```

Resolve should resolve the `List[str]` in the first two resolve calls. Further be idempotent, as long as nothing nothing new is registered and the `resolve_all` call should not effect the result of subsequent calls to `resolve`.


After this PR the result is: 
```
['hi']
['hi']
[['hi']]
['hi']
```

___


Additionally before this PR the following would run and print `[1]`:
```
container.register(int, instance=1)
print(container.resolve(List[int]))
```
Now it will result in a `MissingDependencyError`